### PR TITLE
app-editors/atom: deny +libressl on libgit2 dep

### DIFF
--- a/app-editors/atom/atom-1.13.1.ebuild
+++ b/app-editors/atom/atom-1.13.1.ebuild
@@ -90,7 +90,7 @@ IUSE=""
 DEPEND="
 	${PYTHON_DEPS}
 	>=app-text/hunspell-1.3.3:=
-	>=dev-libs/libgit2-0.23:=[ssh]
+	>=dev-libs/libgit2-0.23:=[-libressl,ssh]
 	>=gnome-base/libgnome-keyring-3.12:=
 	>=dev-libs/oniguruma-5.9.5:=
 	>=dev-util/ctags-5.8


### PR DESCRIPTION
Atom relies on BIO_get_new_index in libgit2 that is not present with libressl.